### PR TITLE
fix: sort package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,12 @@
     "rimraf": "^3.0.2",
     "tar": "^6.1.0"
   },
+  "dependencies": {
+    "axios": "0.24.0",
+    "rimraf": "3.0.2",
+    "tar": "6.1.11",
+    "tmp": "0.2.1"
+  },
   "devDependencies": {
     "@codedependant/semantic-release-docker": "3.1.2",
     "@semantic-release/exec": "6.0.2",
@@ -29,11 +35,5 @@
   },
   "files": [
     "npm/"
-  ],
-  "dependencies": {
-    "axios": "0.24.0",
-    "rimraf": "3.0.2",
-    "tar": "6.1.11",
-    "tmp": "0.2.1"
-  }
+  ]
 }


### PR DESCRIPTION
The real reason for this commit is to publish a new version.

Looks like I don't have all the kinks worked out of this
GitHub/semantic-release workflow. I think the issue is I published a
beta version on the `beta` branch, but when I merged that into `master`
then the tag from `beta` existed on `master` and then there was no
trigger for a new release.