### PR TITLE
fix(make-depend): do not generate link make target

### DIFF
--- a/src/make_depend.rs
+++ b/src/make_depend.rs
@@ -138,7 +138,7 @@ pub fn make_dependency_makefile(opts: crate::opts::MakeDepend) -> Result<(), Box
         scoped_package_name: &scoped_package_name,
         unscoped_package_name: &unscoped_package_name,
         inclusive_internal_dependency_package_jsons: &inclusive_internal_dependencies
-            .into_iter()
+            .iter()
             .map(|internal_dependency| {
                 internal_dependency
                     .join("package.json")

--- a/templates/makefile
+++ b/templates/makefile
@@ -12,10 +12,6 @@ MAKEDEPEND = $(MONOREPO) make-depend \
 
 {{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS = {{ inclusive_internal_dependency_package_jsons.join(" \\\n") }}
 
-{{ package_directory }}/tsconfig.json: node_modules {{ package_directory }}/package.json
-	$(MONOREPO) link --root {{ root }}
-	@touch --no-create $@
-
 {{ package_directory }}/node_modules: node_modules $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS)
 	@$(MAKEDEPEND)
 	$(LERNA) bootstrap --force-local --scope={{ scoped_package_name }} --include-dependencies


### PR DESCRIPTION
As this may be specified in the monorepo root with a grouped target[^1]
such that `monorepo link` is run even less frequently.

[^1]: https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html