### PR TITLE
fix: declare monorepo bin as prereq for generated makefile

### DIFF
--- a/templates/makefile
+++ b/templates/makefile
@@ -12,7 +12,7 @@ MAKEDEPEND = $(MONOREPO) make-depend \
 
 {{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS = {{ inclusive_internal_dependency_package_jsons.join(" \\\n") }}
 
-{{ package_directory }}/node_modules: node_modules $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS)
+{{ package_directory }}/node_modules: $(MONOREPO) $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS)
 	@$(MAKEDEPEND)
 	$(LERNA) bootstrap --force-local --scope={{ scoped_package_name }} --include-dependencies
 	@touch $@


### PR DESCRIPTION
Modify the prerequisites list of the target that invokes `monorepo make-depend`
to include the `monorepo` binary directly, rather than the entire node_modules
directly.

This improves resilience in the event that a user interrupts `npm ci` or
`npm install`; these commands will leave behind an incomplete node_modules
directory. If we instead depend on the `monorepo` binary, when GNU make cannot
find that binary it will re-invoke `npm ci` to recover from the inconsistent
node_modules state.