### PR TITLE
fix: update mtime of downloaded binary after installation

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -26,6 +26,12 @@ const linkBinaryIntoBin = () => {
   // If this fails and throws an error, we'll end up leaving the temporary file there,
   // which is harmless.
   fs.renameSync(tempPath, desiredPath)
+
+  // By default, the downloaded file preserves the mtime of the binary created by GitHub
+  // Actions. For a seamless GNU Make experience on local machines, we want to update the
+  // mtime of this binary to the time of download.
+  const now = new Date()
+  fs.utimesSync(desiredPath, now, now)
 }
 
 // Downloaded binary to /bin/{ name }


### PR DESCRIPTION
This commit adds a step to the `npm install` process, that of updating
the downloaded binary's mtime to the current time.

Apparently, the binary created by GitHub Actions retains its original
creation mtime when downloaded by the postinstall script. This interferes
with GNU Make targets that examine the mtime of the `monorepo` binary.

Instead, we accurately reflect the install time in the mtime of the
downloaded binary via the `fs.utimesSync` function offered by Node.js.