### PR TITLE
fix(make-depend): use order-only prerequisite for hardlink source

### DIFF
--- a/templates/makefile
+++ b/templates/makefile
@@ -34,8 +34,9 @@ dist/{{ scoped_package_name.trim_start_matches("@").replace("/", "-") }}.tgz: | 
 {{ package_directory }}/.internal-npm-dependencies:
 	mkdir $@
 
-{{ package_directory }}/.internal-npm-dependencies/%.tgz: dist/%.tgz | {{ package_directory }}/.internal-npm-dependencies
-	ln $< $@
+{{ package_directory }}/.internal-npm-dependencies/%.tgz: | dist/%.tgz {{ package_directory }}/.internal-npm-dependencies
+	rm -f $@
+	ln $(firstword $|) $@
 
 .PHONY: {{ unscoped_package_name }}-docker-dependencies
 {{ unscoped_package_name }}-docker-dependencies: $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_NPM_DEPENDENCIES)


### PR DESCRIPTION
Previously, we described that the hard link "target" (the link of the original)
was built by the "source" (the original), which isn't entirely accurate, since
the files are one and the same.

If somehow (not sure how but I'm looking at it) the timestamp of the hard link
"source" is set later than the timestamp of the hard link "source", our current
make target tries to run `ln` again, producing this error

```
ln: failed to create hard link 'packages/my-package/.internal-npm-dependencies/scoped-neat-package-name.tgz': File exists
```

As a fix, we update the make target to specify that the hard link "source" is an
order-only prerequisite, meaning the recipe will only be run if the "source" does
not exist yet. If the timestamp of the "target" is later than the "source", no
action is taken.

As an extra precaution against the case where the "target" exists but the "source"
doesn't, we also `rm -f` the "target" so the `ln` will not produce this error again.