### PR TITLE
fix(make-depends): always create internal npm deps directory

### DIFF
--- a/templates/makefile
+++ b/templates/makefile
@@ -39,5 +39,5 @@ dist/{{ scoped_package_name.trim_start_matches("@").replace("/", "-") }}.tgz: | 
 	ln $(firstword $|) $@
 
 .PHONY: {{ unscoped_package_name }}-docker-dependencies
-{{ unscoped_package_name }}-docker-dependencies: $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_NPM_DEPENDENCIES)
+{{ unscoped_package_name }}-docker-dependencies: $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_NPM_DEPENDENCIES) | {{ package_directory }}/.internal-npm-dependencies
 {% endif %}


### PR DESCRIPTION
This commit adds an order-only prerequisite to the generated
`<package>-docker-dependencies` make target, that of the
`.internal-npm-dependencies` directory.

Currently, the `.internal-npm-dependencies` directory is not created
if there happen to be no use of internal dependencies, which means
the Dockerfile commands

```dockerfile
COPY my-package/.internal-npm-dependencies /tmp/internal-npm-dependencies
```

will not work in all cases (meaning for packages with dependencies and
for those without).

We add the order-only prerequisite so this `.internal-npm-dependencies`
directory is always created, and this `COPY` command will always succeed.