### PR TITLE
fix(make-depend)!: remove use of force-local

### DIFF
--- a/templates/makefile
+++ b/templates/makefile
@@ -15,7 +15,7 @@ MAKEDEPEND = $(MONOREPO) make-depend \
 
 {{ package_directory }}/node_modules: $(MONOREPO) $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS_INCLUSIVE)
 	@$(MAKEDEPEND)
-	$(LERNA) bootstrap --force-local --scope={{ scoped_package_name }} --include-dependencies
+	$(LERNA) bootstrap --scope={{ scoped_package_name }} --include-dependencies
 	@touch $@
 
 $({{ unscoped_package_name.replace("-", "_").to_uppercase() }}_INTERNAL_DEPENDENCY_MANIFESTS_INCLUSIVE):


### PR DESCRIPTION
This commit removes hard-coded use of `lerna bootstrap`'s
`--force-local`[^1] command, so that monorepos that don't want to
opt in to this behavior are not forced to.

For projects that wish to include the `--force-local` flag on every
invocation to `lerna bootstrap`, perhaps to prevent dependency
confusion attacks, we recommend specifying this in the lerna
manifest. For example, your lerna.json could look like

```
{
  "packages": [
    "packages/*"
  ],
  "command": {
    "bootstrap": {
      "forceLocal": true
    }
  }
}
```

To prevent the case where a project was expecting `--force-local`
to be applied, but not specifying this in the configuration file,
we consider this a breaking change.

[^1]: https://github.com/lerna/lerna/blob/main/commands/bootstrap/README.md#--force-local

BREAKING CHANGE: do not specify `--force-local` in makefiles generated by `make-depend`