### PR TITLE
fix: strip debug symbols from release builds

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -14,6 +14,7 @@ jobs:
 
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
+        rust-version: 1.59.0
         command: check licenses
 
   check_sources:
@@ -25,4 +26,5 @@ jobs:
 
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
+        rust-version: 1.59.0
         command: check sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ semantic-release-rust = "1.0.0-alpha.8"
 [profile.release]
 lto = true
 codegen-units = 1
+strip = true


### PR DESCRIPTION
for smaller code size. On my x86_64 GNU/Linux maching, the release
binary shrank from 3.7M to 2.1M.