### PR TITLE
ci: fix semantic-release prelrease configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,4 @@
 {
-  "branches": [
-    "master",
-    "alpha",
-    "beta"
-  ],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Previously, prereleases on the beta branch were not "pre-" enough,
meaning releases were published to the `beta` dist-tag but not
marked as pre-release in version number.  This caused the merge of
a prerelease from the beta branch into master to not be re-published
as a full or non-pre release.

The issue is that I overrode the default `branches` semantic-release
setting[^2] that does what I intended with a configuration that
specified that releases from the beta branch should not be treated
as prereleases.

Closes #140

[^2]: https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches