### PR TITLE
fix: do not require a version key in the lerna manifest

### DIFF
--- a/src/lerna_manifest.rs
+++ b/src/lerna_manifest.rs
@@ -13,7 +13,6 @@ use crate::package_manifest::PackageManifest;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct LernaManifestFile {
-    version: String,
     packages: Vec<String>,
 }
 


### PR DESCRIPTION
Stop enforcing that this `version` key exists, since we don't use
it. This should widen the set of `lerna.json` manifests that can be
used as valid inputs to this program.

Additionally, we should expect a small (microseconds or less)
performance improvement since serde is not parsing this field.