### PR TITLE
Add lint-lerna-manifest command

### DIFF
--- a/src/lint_lerna_manifest.rs
+++ b/src/lint_lerna_manifest.rs
@@ -1,0 +1,114 @@
+use std::error::Error;
+use std::fmt::{Display, Debug, Formatter, Result as FmtResult};
+use std::path::PathBuf;
+use std::collections::HashSet;
+use globwalk::{FileType, GlobWalkerBuilder};
+use crate::package_manifest::PackageManifest;
+use crate::configuration_file::ConfigurationFile;
+use crate::monorepo_manifest::MonorepoManifest;
+use crate::opts::LintLernaManifest;
+
+pub fn lint_lerna_manifest(args: LintLernaManifest) -> Result<(), Box<dyn Error>> {
+    let LintLernaManifest {
+        root,
+    } = args;
+    let lerna_manifest_keys = get_lerna_manifest_keys(root.clone())?;
+    let package_names = get_packages_from_globwalk(root.clone())?;
+    let keys_only_in_one_manifest = lerna_manifest_keys
+        .symmetric_difference(&package_names)
+        .cloned()
+        .map(|key| DifferentManifestEntry {
+            in_lerna_manifest: lerna_manifest_keys.contains(&key),
+            key,
+        })
+        .collect::<Vec<_>>();
+    if keys_only_in_one_manifest.is_empty() {
+        Ok(())
+    } else {
+        Err(Box::new(LernaManifestLintErr::DifferentManifestEntries(keys_only_in_one_manifest)))
+    }
+}
+
+fn get_lerna_manifest_keys(root: PathBuf) -> Result<HashSet<String>, Box<dyn Error>> {
+    let keys = MonorepoManifest::from_lerna_manifest(root)?
+        .into_package_manifests_by_package_name()?
+        .into_keys()
+        .collect();
+    Ok(keys)
+}
+
+fn get_packages_from_globwalk(root: PathBuf) -> Result<HashSet<String>, Box<dyn Error>> {
+    let patterns = &[
+        "!node_modules/",
+        "package.json"
+    ];
+    GlobWalkerBuilder::from_patterns(&root, patterns)
+        .file_type(FileType::FILE)
+        .min_depth(1)
+        .build()
+        .expect("Unable to create glob")
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|dir_entry| {
+            PackageManifest::from_directory(
+                root.as_ref(),
+                dir_entry
+                    .path()
+                    .parent()
+                    .expect("Unexpected package in monorepo root")
+                    .strip_prefix(&root)
+                    .expect("Unexpected package in monorepo root"),
+            )
+        })
+        .filter(|manifest| {
+            // filter out non-@bitgo packages
+            if let Ok(manifest) = manifest {
+                manifest.contents.name.find("@bitgo/").is_some()
+            } else {
+                true  // we want to keep errors
+            }
+        })
+        .map(|manifest| manifest.map(|manifest| manifest.contents.name))
+        .collect::<Result<_, Box<dyn Error>>>()
+}
+
+enum LernaManifestLintErr {
+    DifferentManifestEntries(Vec<DifferentManifestEntry>),
+}
+
+impl Display for LernaManifestLintErr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            LernaManifestLintErr::DifferentManifestEntries(entries) => {
+                for &DifferentManifestEntry { ref key, in_lerna_manifest } in entries {
+                    if in_lerna_manifest {
+                        writeln!(f, "\
+                            Found package '{key}' in lerna manifest couldn't find \
+                            package directory\
+                        ")?;
+                    } else {
+                        writeln!(f, "\
+                            Found package '{key}' but couldn't find it in lerna manifest\
+                        ")?;
+                    }
+                }
+            },
+        }
+
+        Ok(())
+    }
+}
+
+impl Debug for LernaManifestLintErr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        Display::fmt(&self, f)
+    }
+}
+
+impl Error for LernaManifestLintErr {}
+
+#[derive(Debug)]
+struct DifferentManifestEntry {
+    key: String,
+    in_lerna_manifest: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod configuration_file;
 mod io;
 mod link;
+mod lint_lerna_manifest;
 mod make_depend;
 mod monorepo_manifest;
 mod opts;
@@ -23,5 +24,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         opts::ClapSubCommand::Pin(args) => pin::pin_version_numbers_in_internal_packages(args),
         opts::ClapSubCommand::MakeDepend(args) => make_depend::make_dependency_makefile(args),
         opts::ClapSubCommand::Query(args) => query::handle_subcommand(args),
+        opts::ClapSubCommand::LintLernaManifest(args) => lint_lerna_manifest::lint_lerna_manifest(args),
     }
 }

--- a/src/monorepo_manifest.rs
+++ b/src/monorepo_manifest.rs
@@ -72,7 +72,7 @@ impl MonorepoManifest {
     const LERNA_MANIFEST_FILENAME: &'static str = "lerna.json";
     const PACKAGE_MANIFEST_FILENAME: &'static str = "package.json";
 
-    fn from_lerna_manifest<P>(root: P) -> Result<MonorepoManifest, Box<dyn Error>>
+    pub fn from_lerna_manifest<P>(root: P) -> Result<MonorepoManifest, Box<dyn Error>>
     where
         P: AsRef<Path>,
     {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,6 +19,8 @@ pub enum ClapSubCommand {
     MakeDepend(MakeDepend),
     #[clap(about = "Query properties of the current monorepo state")]
     Query(Query),
+    #[clap(about = "Lint the lerna manifest for unregistered new packages")]
+    LintLernaManifest(LintLernaManifest),
 }
 
 #[derive(Parser)]
@@ -62,6 +64,13 @@ pub struct Query {
     /// internal-dependencies
     #[clap(subcommand)]
     pub subcommand: ClapQuerySubCommand,
+}
+
+#[derive(Parser)]
+pub struct LintLernaManifest {
+    /// Path to monorepo root
+    #[clap(short, long, default_value = ".")]
+    pub root: PathBuf,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
As of PR creation, there is a bug: some packages found via glob-walk are being considered relevant despite not being relevant *semantically*. We need a more bulletproof way of differentiating between "packages relevant to lerna linting" and "packages that just happen to be there".

Ticket: BG-46488