### PR TITLE
feat: add subcommand to lint depenendency versions for consistent values

### DIFF
--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+use std::error::Error;
+
+use crate::opts;
+
+use crate::configuration_file::ConfigurationFile;
+use crate::monorepo_manifest::MonorepoManifest;
+
+pub fn handle_subcommand(opts: opts::Lint) -> Result<(), Box<dyn Error>> {
+    match opts.subcommand {
+        opts::ClapLintSubCommand::DependencyVersion(args) => lint_dependency_version(&args),
+    }
+}
+
+fn most_common_dependency_version(
+    package_manifests_by_dependency_version: &HashMap<String, Vec<String>>,
+) -> Option<String> {
+    package_manifests_by_dependency_version
+        .iter()
+        // Map each dependecy version to its number of occurrences
+        .map(|(dependency_version, package_manifests)| {
+            (dependency_version, package_manifests.len())
+        })
+        // Take the max by value
+        .max_by(|a, b| a.1.cmp(&b.1))
+        .map(|(k, _v)| k.to_owned())
+}
+
+fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<(), Box<dyn Error>> {
+    let opts::DependencyVersion { root, dependencies } = opts;
+
+    let lerna_manifest = MonorepoManifest::from_directory(&root)?;
+    let package_manifest_by_package_name = lerna_manifest.package_manifests_by_package_name()?;
+
+    let mut is_exit_success = true;
+
+    for dependency in dependencies {
+        let package_manifests_by_dependency_version: HashMap<String, Vec<String>> =
+            package_manifest_by_package_name
+                .values()
+                .filter_map(|package_manifest| {
+                    package_manifest
+                        .get_dependency_version(&dependency)
+                        .map(|dependency_version| (package_manifest, dependency_version))
+                })
+                .fold(
+                    HashMap::new(),
+                    |mut accumulator, (package_manifest, dependency_version)| {
+                        let packages_using_this_dependency_version =
+                            accumulator.entry(dependency_version).or_default();
+                        packages_using_this_dependency_version.push(
+                            package_manifest
+                                .path()
+                                .into_os_string()
+                                .into_string()
+                                .expect("Path not UTF-8 encoded"),
+                        );
+                        accumulator
+                    },
+                );
+
+        if package_manifests_by_dependency_version.keys().len() <= 1 {
+            return Ok(());
+        }
+
+        let expected_version_number =
+            most_common_dependency_version(&package_manifests_by_dependency_version)
+                .expect("Expected dependency to be used in at least one package");
+
+        println!("Linting versions of dependency \"{}\"", &dependency);
+
+        package_manifests_by_dependency_version
+            .into_iter()
+            // filter out the packages using the expected dependency version
+            .filter(|(dependency_version, _package_manifests)| {
+                !dependency_version.eq(&expected_version_number)
+            })
+            .for_each(|(dependency_version, package_manifests)| {
+                package_manifests.into_iter().for_each(|package_manifest| {
+                    println!(
+                        "\tIn {}, expected version {} but found version {}",
+                        &package_manifest, &expected_version_number, dependency_version
+                    );
+                });
+            });
+
+        is_exit_success = false;
+    }
+
+    if is_exit_success {
+        return Ok(());
+    } else {
+        return Err("Found unexpected dependency versions".into());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod configuration_file;
 mod io;
 mod link;
+mod lint;
 mod make_depend;
 mod monorepo_manifest;
 mod opts;
@@ -23,5 +24,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         opts::ClapSubCommand::Pin(args) => pin::pin_version_numbers_in_internal_packages(args),
         opts::ClapSubCommand::MakeDepend(args) => make_depend::make_dependency_makefile(args),
         opts::ClapSubCommand::Query(args) => query::handle_subcommand(args),
+        opts::ClapSubCommand::Lint(args) => lint::handle_subcommand(args),
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,6 +19,8 @@ pub enum ClapSubCommand {
     MakeDepend(MakeDepend),
     #[clap(about = "Query properties of the current monorepo state")]
     Query(Query),
+    #[clap(about = "Lint internal packages for consistent use of external dependency versions")]
+    Lint(Lint),
 }
 
 #[derive(Parser)]
@@ -59,7 +61,6 @@ pub struct MakeDepend {
 
 #[derive(Parser)]
 pub struct Query {
-    /// internal-dependencies
     #[clap(subcommand)]
     pub subcommand: ClapQuerySubCommand,
 }
@@ -72,6 +73,12 @@ pub enum ClapQuerySubCommand {
     InternalDependencies(InternalDependencies),
 }
 
+#[derive(ArgEnum, Clone)]
+pub enum InternalDependenciesFormat {
+    Name,
+    Path,
+}
+
 #[derive(Parser)]
 pub struct InternalDependencies {
     /// Path to monorepo root
@@ -82,8 +89,24 @@ pub struct InternalDependencies {
     pub format: InternalDependenciesFormat,
 }
 
-#[derive(ArgEnum, Clone)]
-pub enum InternalDependenciesFormat {
-    Name,
-    Path,
+#[derive(Parser)]
+pub struct Lint {
+    #[clap(subcommand)]
+    pub subcommand: ClapLintSubCommand,
+}
+
+#[derive(Parser)]
+pub enum ClapLintSubCommand {
+    #[clap(about = "Lint the used versions of an external dependency for consistency")]
+    DependencyVersion(DependencyVersion),
+}
+
+#[derive(Parser)]
+pub struct DependencyVersion {
+    /// Path to monorepo root
+    #[clap(short, long, default_value = ".")]
+    pub root: PathBuf,
+    /// External dependency to lint for consistency of version used
+    #[clap(short, long = "dependency")]
+    pub dependencies: Vec<String>,
 }

--- a/src/package_manifest.rs
+++ b/src/package_manifest.rs
@@ -88,6 +88,39 @@ impl AsRef<PackageManifest> for PackageManifest {
 }
 
 impl PackageManifest {
+    // Get the dependency
+    pub fn get_dependency_version<S>(&self, dependency: S) -> Option<String>
+    where
+        S: AsRef<str>,
+    {
+        static DEPENDENCY_GROUPS: &[&str] = &[
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+        ];
+
+        DEPENDENCY_GROUPS
+            .iter()
+            // only iterate over the objects corresponding to each dependency group
+            .filter_map(|dependency_group| {
+                self.contents
+                    .extra_fields
+                    .get(dependency_group)?
+                    .as_object()
+            })
+            // get the target dependency version, if exists
+            .filter_map(|dependency_group_value| {
+                dependency_group_value
+                    .get(dependency.as_ref())
+                    // DISCUSS(Grayson): neither clone nor cloned work here, only to_owned
+                    // How do I resolve this with https://github.com/typescript-tools/rust-implementation/pull/141#discussion_r845294514 ?
+                    .and_then(|version_value| version_value.as_str().map(|a| a.to_owned()))
+            })
+            .take(1)
+            .next()
+    }
+
     pub fn internal_dependencies_iter<'a, T>(
         &'a self,
         package_manifests_by_package_name: &'a HashMap<String, &'a T>,
@@ -106,7 +139,10 @@ impl PackageManifest {
             .iter()
             // only iterate over the objects corresponding to each dependency group
             .filter_map(|dependency_group| {
-                self.contents.extra_fields.get(dependency_group)?.as_object()
+                self.contents
+                    .extra_fields
+                    .get(dependency_group)?
+                    .as_object()
             })
             // get all dependency names from all groups
             .flat_map(|dependency_group_value| dependency_group_value.keys())
@@ -132,8 +168,8 @@ impl PackageManifest {
         while let Some(current_manifest) = to_visit_package_manifests.pop_front() {
             seen_package_names.insert(&current_manifest.contents.name);
 
-            for dependency in current_manifest
-                .internal_dependencies_iter(package_manifest_by_package_name)
+            for dependency in
+                current_manifest.internal_dependencies_iter(package_manifest_by_package_name)
             {
                 internal_dependencies.insert(dependency.contents.name.to_owned());
                 if !seen_package_names.contains(&dependency.contents.name) {


### PR DESCRIPTION
The `lint-dependency-version` subcommand takes a list of dependencies,
and for each dependency will test that there is at most one version
of that dependency in use throughout the target monorepo.

If this condition is violated, the command will exit non-zero exit code.

The plan is to use this in CI to enforce monorepo invariants for using
only a single version of a given external dependency; for example,
`typescript`.

Ideally we separate out the library and binary code in this crate,
and later we can write multiple binaries that use this library, one
of which will invoke this new code and can function as a stand-alone
Drone plugin. Thinking about it now, the coupling to Drone is not a
goal of this crate but importing the library portion of this codebase
from a different crate will be a prerequisite for the plugin.