### PR TITLE
feat: add subcommand to lint depenendency versions for consistent values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,19 +699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "rust_typescript_tools"
-version = "0.0.0-semantically-released"
-dependencies = [
- "askama",
- "clap 3.1.8",
- "globwalk",
- "pathdiff",
- "semantic-release-rust",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +954,20 @@ dependencies = [
  "chrono",
  "combine",
  "linked-hash-map",
+]
+
+[[package]]
+name = "typescript_tools"
+version = "0.0.0-semantically-released"
+dependencies = [
+ "anyhow",
+ "askama",
+ "clap 3.1.8",
+ "globwalk",
+ "pathdiff",
+ "semantic-release-rust",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,15 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dpc-pariter"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a6f60e0061d01135c7e9b77486a7f5a8e63ba14acbdbca73e42007cfd8a1c91"
-dependencies = [
- "pariter",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,8 +1058,8 @@ dependencies = [
  "anyhow",
  "askama",
  "clap 3.1.8",
- "dpc-pariter",
  "globwalk",
+ "pariter",
  "pathdiff",
  "semantic-release-rust",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +320,15 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "dpc-pariter"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a6f60e0061d01135c7e9b77486a7f5a8e63ba14acbdbca73e42007cfd8a1c91"
+dependencies = [
+ "pariter",
 ]
 
 [[package]]
@@ -509,6 +577,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +653,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +693,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "pariter"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "324a62b9e7b5f270c0acc92a2040f8028bb643f959f9c068f11a7864f327e3d9"
+dependencies = [
+ "crossbeam",
+ "crossbeam-channel",
+ "num_cpus",
 ]
 
 [[package]]
@@ -718,6 +816,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semantic-release-rust"
@@ -963,6 +1067,7 @@ dependencies = [
  "anyhow",
  "askama",
  "clap 3.1.8",
+ "dpc-pariter",
  "globwalk",
  "pathdiff",
  "semantic-release-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 askama = "0.11"
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 globwalk = "0.8.1"
+dpc-pariter = "0.5.1"
 pathdiff = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust_typescript_tools"
+name = "typescript_tools"
 version = "0.0.0-semantically-released"
 edition = "2021"
 
@@ -8,6 +8,7 @@ name = "monorepo"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0"
 askama = "0.11"
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 globwalk = "0.8.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 askama = "0.11"
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 globwalk = "0.8.1"
-dpc-pariter = "0.5.1"
+pariter = "0.5.1"
 pathdiff = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/src/configuration_file.rs
+++ b/src/configuration_file.rs
@@ -1,5 +1,6 @@
-use std::error::Error;
 use std::path::{Path, PathBuf};
+
+use anyhow::Result;
 
 /// Configuration file for some component of the monorepo.
 pub trait ConfigurationFile<T> {
@@ -8,7 +9,7 @@ pub trait ConfigurationFile<T> {
 
     /// Create an instance of this configuration file by reading
     /// the specified file from this directory on disk.
-    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<T, Box<dyn Error>>
+    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<T>
     where
         P: AsRef<Path>;
 
@@ -20,5 +21,5 @@ pub trait ConfigurationFile<T> {
     fn path(&self) -> PathBuf;
 
     /// Write this configuration file to disk.
-    fn write(&self) -> Result<(), Box<dyn Error>>;
+    fn write(&self) -> Result<()>;
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,8 @@
-use std::error::Error;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+
+use anyhow::Result;
 
 use serde::{Deserialize, Serialize};
 
@@ -19,7 +20,7 @@ pub struct TypescriptParentProjectReference {
 pub fn write_project_references<P: AsRef<Path>>(
     path: P,
     references: &TypescriptParentProjectReference,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<()> {
     let file = File::create(&path)?;
     let mut writer = BufWriter::new(file);
     serde_json::to_writer_pretty(&mut writer, references)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+#![forbid(unsafe_code)]
+
+mod configuration_file;
+mod io;
+mod monorepo_manifest;
+mod package_manifest;
+mod typescript_config;
+
+pub mod link;
+pub mod lint;
+pub mod make_depend;
+pub mod opts;
+pub mod pin;
+pub mod query;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 
 use pathdiff::diff_paths;
 
@@ -205,9 +205,10 @@ pub fn link_typescript_project_references(opts: opts::Link) -> Result<()> {
     let is_dependencies_link_success = link_package_dependencies(&opts, &lerna_manifest)
         .expect("Unable to link internal package dependencies");
 
-    if opts.check_only && !(is_children_link_success && is_dependencies_link_success) {
-        return Err(anyhow!("Found out-of-date project references"));
-    }
+    ensure!(
+        opts.check_only && !(is_children_link_success && is_dependencies_link_success),
+        "Found out-of-date project references"
+    );
 
     // TODO(7): create `tsconfig.settings.json` files
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, ensure, Result};
+use anyhow::{anyhow, bail, Result};
 
 use pathdiff::diff_paths;
 
@@ -205,10 +205,9 @@ pub fn link_typescript_project_references(opts: opts::Link) -> Result<()> {
     let is_dependencies_link_success = link_package_dependencies(&opts, &lerna_manifest)
         .expect("Unable to link internal package dependencies");
 
-    ensure!(
-        opts.check_only && !(is_children_link_success && is_dependencies_link_success),
-        "Found out-of-date project references"
-    );
+    if opts.check_only && !(is_children_link_success && is_dependencies_link_success) {
+        bail!("Found out-of-date project references")
+    }
 
     // TODO(7): create `tsconfig.settings.json` files
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::{ensure, Result};
 
 use crate::opts;
 
@@ -88,9 +88,6 @@ fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<()> {
         is_exit_success = false;
     }
 
-    if is_exit_success {
-        return Ok(());
-    } else {
-        return Err(anyhow!("Found unexpected dependency versions"));
-    }
+    ensure!(is_exit_success, "Found unexpected dependency versions");
+    Ok(())
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+use std::error::Error;
+
+use crate::opts;
+
+use crate::configuration_file::ConfigurationFile;
+use crate::monorepo_manifest::MonorepoManifest;
+
+pub fn handle_subcommand(opts: opts::Lint) -> Result<(), Box<dyn Error>> {
+    match opts.subcommand {
+        opts::ClapLintSubCommand::DependencyVersion(args) => lint_dependency_version(&args),
+    }
+}
+
+fn most_common_dependency_version(
+    package_manifests_by_dependency_version: &HashMap<String, Vec<String>>,
+) -> Option<String> {
+    package_manifests_by_dependency_version
+        .iter()
+        // Map each dependecy version to its number of occurrences
+        .map(|(dependency_version, package_manifests)| {
+            (dependency_version, package_manifests.len())
+        })
+        // Take the max by value
+        .max_by(|a, b| a.1.cmp(&b.1))
+        .map(|(k, _v)| k.to_owned())
+}
+
+fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<(), Box<dyn Error>> {
+    let opts::DependencyVersion { root, dependencies } = opts;
+
+    let lerna_manifest = MonorepoManifest::from_directory(&root)?;
+    let package_manifest_by_package_name = lerna_manifest.package_manifests_by_package_name()?;
+
+    let mut is_exit_success = true;
+
+    for dependency in dependencies {
+        let package_manifests_by_dependency_version: HashMap<String, Vec<String>> =
+            package_manifest_by_package_name
+                .values()
+                .filter_map(|package_manifest| {
+                    package_manifest
+                        .get_dependency_version(&dependency)
+                        .map(|dependency_version| (package_manifest, dependency_version))
+                })
+                .fold(
+                    HashMap::new(),
+                    |mut accumulator, (package_manifest, dependency_version)| {
+                        let packages_using_this_dependency_version =
+                            accumulator.entry(dependency_version).or_default();
+                        packages_using_this_dependency_version.push(
+                            package_manifest
+                                .path()
+                                .into_os_string()
+                                .into_string()
+                                .expect("Path not UTF-8 encoded"),
+                        );
+                        accumulator
+                    },
+                );
+
+        if package_manifests_by_dependency_version.keys().len() <= 1 {
+            return Ok(());
+        }
+
+        let expected_version_number =
+            most_common_dependency_version(&package_manifests_by_dependency_version)
+                .expect("Expected dependency to be used in at least one package");
+
+        println!("Linting versions of dependency \"{}\"", &dependency);
+
+        package_manifests_by_dependency_version
+            .into_iter()
+            // filter out the packages using the expected dependency version
+            .filter(|(dependency_version, _package_manifests)| {
+                !dependency_version.eq(&expected_version_number)
+            })
+            .for_each(|(dependency_version, package_manifests)| {
+                package_manifests.into_iter().for_each(|package_manifest| {
+                    println!(
+                        "\tIn {}, expected version {} but found version {}",
+                        &package_manifest, &expected_version_number, dependency_version
+                    );
+                });
+            });
+
+        is_exit_success = false;
+    }
+
+    if is_exit_success {
+        return Ok(());
+    } else {
+        return Err("Found unexpected dependency versions".into());
+    }
+}

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::{anyhow, Result};
 
 use crate::opts;
 
 use crate::configuration_file::ConfigurationFile;
 use crate::monorepo_manifest::MonorepoManifest;
 
-pub fn handle_subcommand(opts: opts::Lint) -> Result<(), Box<dyn Error>> {
+pub fn handle_subcommand(opts: opts::Lint) -> Result<()> {
     match opts.subcommand {
         opts::ClapLintSubCommand::DependencyVersion(args) => lint_dependency_version(&args),
     }
@@ -26,7 +27,7 @@ fn most_common_dependency_version(
         .map(|(k, _v)| k.to_owned())
 }
 
-fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<(), Box<dyn Error>> {
+fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<()> {
     let opts::DependencyVersion { root, dependencies } = opts;
 
     let lerna_manifest = MonorepoManifest::from_directory(&root)?;
@@ -90,6 +91,6 @@ fn lint_dependency_version(opts: &opts::DependencyVersion) -> Result<(), Box<dyn
     if is_exit_success {
         return Ok(());
     } else {
-        return Err("Found unexpected dependency versions".into());
+        return Err(anyhow!("Found unexpected dependency versions"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod configuration_file;
 mod io;
 mod link;
+mod lint;
 mod make_depend;
 mod monorepo_manifest;
 mod opts;
@@ -23,5 +24,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         opts::ClapSubCommand::Pin(args) => pin::pin_version_numbers_in_internal_packages(args),
         opts::ClapSubCommand::MakeDepend(args) => make_depend::make_dependency_makefile(args),
         opts::ClapSubCommand::Query(args) => query::handle_subcommand(args),
+        opts::ClapSubCommand::Lint(args) => lint::handle_subcommand(args),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,17 @@
 #![forbid(unsafe_code)]
 
-mod configuration_file;
-mod io;
-mod link;
-mod lint;
-mod make_depend;
-mod monorepo_manifest;
-mod opts;
-mod package_manifest;
-mod pin;
-mod query;
-mod typescript_config;
-
-use std::error::Error;
+use anyhow::Result;
 
 use clap::Parser;
 
-fn main() -> Result<(), Box<dyn Error>> {
+use typescript_tools::link;
+use typescript_tools::lint;
+use typescript_tools::make_depend;
+use typescript_tools::opts;
+use typescript_tools::pin;
+use typescript_tools::query;
+
+fn main() -> Result<()> {
     let opts = opts::Opts::parse();
 
     match opts.subcommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,7 @@ use anyhow::Result;
 
 use clap::Parser;
 
-use typescript_tools::link;
-use typescript_tools::lint;
-use typescript_tools::make_depend;
-use typescript_tools::opts;
-use typescript_tools::pin;
-use typescript_tools::query;
+use typescript_tools::{link, lint, make_depend, opts, pin, query};
 
 fn main() -> Result<()> {
     let opts = opts::Opts::parse();

--- a/src/make_depend.rs
+++ b/src/make_depend.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
-use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
 
+use anyhow::Result;
+
 use askama::Template;
+
 use pathdiff::diff_paths;
 
 use crate::configuration_file::ConfigurationFile;
@@ -25,7 +27,7 @@ struct MakefileTemplate<'a> {
     internal_npm_dependencies_exclusive: &'a Vec<&'a str>,
 }
 
-pub fn make_dependency_makefile(opts: crate::opts::MakeDepend) -> Result<(), Box<dyn Error>> {
+pub fn make_dependency_makefile(opts: crate::opts::MakeDepend) -> Result<()> {
     let lerna_manifest = MonorepoManifest::from_directory(&opts.root)?;
     let package_manifest = PackageManifest::from_directory(&opts.root, &opts.package_directory)?;
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -4,7 +4,7 @@ use clap::{crate_version, ArgEnum, Parser};
 
 #[derive(Parser)]
 #[clap(name = "monorepo", version = crate_version!(), author = "Eric Crosson <eric.s.crosson@utexas.edu>")]
-pub(crate) struct Opts {
+pub struct Opts {
     #[clap(subcommand)]
     pub subcommand: ClapSubCommand,
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -19,6 +19,8 @@ pub enum ClapSubCommand {
     MakeDepend(MakeDepend),
     #[clap(about = "Query properties of the current monorepo state")]
     Query(Query),
+    #[clap(about = "Lint internal packages for consistent use of external dependency versions")]
+    Lint(Lint),
 }
 
 #[derive(Parser)]
@@ -59,7 +61,6 @@ pub struct MakeDepend {
 
 #[derive(Parser)]
 pub struct Query {
-    /// internal-dependencies
     #[clap(subcommand)]
     pub subcommand: ClapQuerySubCommand,
 }
@@ -72,6 +73,12 @@ pub enum ClapQuerySubCommand {
     InternalDependencies(InternalDependencies),
 }
 
+#[derive(ArgEnum, Clone)]
+pub enum InternalDependenciesFormat {
+    Name,
+    Path,
+}
+
 #[derive(Parser)]
 pub struct InternalDependencies {
     /// Path to monorepo root
@@ -82,8 +89,24 @@ pub struct InternalDependencies {
     pub format: InternalDependenciesFormat,
 }
 
-#[derive(ArgEnum, Clone)]
-pub enum InternalDependenciesFormat {
-    Name,
-    Path,
+#[derive(Parser)]
+pub struct Lint {
+    #[clap(subcommand)]
+    pub subcommand: ClapLintSubCommand,
+}
+
+#[derive(Parser)]
+pub enum ClapLintSubCommand {
+    #[clap(about = "Lint the used versions of an external dependency for consistency")]
+    DependencyVersion(DependencyVersion),
+}
+
+#[derive(Parser)]
+pub struct DependencyVersion {
+    /// Path to monorepo root
+    #[clap(short, long, default_value = ".")]
+    pub root: PathBuf,
+    /// External dependency to lint for consistency of version used
+    #[clap(short, long = "dependency")]
+    pub dependencies: Vec<String>,
 }

--- a/src/package_manifest.rs
+++ b/src/package_manifest.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::error::Error;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+
+use anyhow::Result;
 
 use serde::{Deserialize, Serialize};
 
@@ -44,7 +45,7 @@ impl DependencyGroup {
 impl ConfigurationFile<PackageManifest> for PackageManifest {
     const FILENAME: &'static str = "package.json";
 
-    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<PackageManifest, Box<dyn Error>>
+    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<PackageManifest>
     where
         P: AsRef<Path>,
     {
@@ -67,7 +68,7 @@ impl ConfigurationFile<PackageManifest> for PackageManifest {
         self.directory.join(Self::FILENAME)
     }
 
-    fn write(&self) -> Result<(), Box<dyn Error>> {
+    fn write(&self) -> Result<()> {
         let file = File::create(
             self.monorepo_root
                 .join(&self.directory)

--- a/src/package_manifest.rs
+++ b/src/package_manifest.rs
@@ -88,6 +88,39 @@ impl AsRef<PackageManifest> for PackageManifest {
 }
 
 impl PackageManifest {
+    // Get the dependency
+    pub fn get_dependency_version<S>(&self, dependency: S) -> Option<String>
+    where
+        S: AsRef<str>,
+    {
+        static DEPENDENCY_GROUPS: &[&str] = &[
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+        ];
+
+        DEPENDENCY_GROUPS
+            .iter()
+            // only iterate over the objects corresponding to each dependency group
+            .filter_map(|dependency_group| {
+                self.contents
+                    .extra_fields
+                    .get(dependency_group)?
+                    .as_object()
+            })
+            // get the target dependency version, if exists
+            .filter_map(|dependency_group_value| {
+                dependency_group_value
+                    .get(dependency.as_ref())
+                    // DISCUSS(Grayson): neither clone nor cloned work here, only to_owned
+                    // How do I resolve this with https://github.com/typescript-tools/rust-implementation/pull/141#discussion_r845294514 ?
+                    .and_then(|version_value| version_value.as_str().map(|a| a.to_owned()))
+            })
+            .take(1)
+            .next()
+    }
+
     pub fn internal_dependencies_iter<'a, T>(
         &'a self,
         package_manifests_by_package_name: &'a HashMap<String, &'a T>,
@@ -106,7 +139,10 @@ impl PackageManifest {
             .iter()
             // only iterate over the objects corresponding to each dependency group
             .filter_map(|dependency_group| {
-                self.contents.extra_fields.get(dependency_group)?.as_object()
+                self.contents
+                    .extra_fields
+                    .get(dependency_group)?
+                    .as_object()
             })
             // get all dependency names from all groups
             .flat_map(|dependency_group_value| dependency_group_value.keys())
@@ -132,8 +168,8 @@ impl PackageManifest {
         while let Some(current_manifest) = to_visit_package_manifests.pop_front() {
             seen_package_names.insert(&current_manifest.contents.name);
 
-            for dependency in current_manifest
-                .internal_dependencies_iter(package_manifest_by_package_name)
+            for dependency in
+                current_manifest.internal_dependencies_iter(package_manifest_by_package_name)
             {
                 internal_dependencies.insert(dependency.contents.name.to_owned());
                 if !seen_package_names.contains(&dependency.contents.name) {

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::{anyhow, Result};
 
 use crate::configuration_file::ConfigurationFile;
 use crate::monorepo_manifest::MonorepoManifest;
@@ -12,9 +13,7 @@ struct UnpinnedDependency {
     expected: String,
 }
 
-pub fn pin_version_numbers_in_internal_packages(
-    opts: crate::opts::Pin,
-) -> Result<(), Box<dyn Error>> {
+pub fn pin_version_numbers_in_internal_packages(opts: crate::opts::Pin) -> Result<()> {
     let lerna_manifest = MonorepoManifest::from_directory(&opts.root)?;
     let mut package_manifest_by_package_name = lerna_manifest
         .into_package_manifests_by_package_name()
@@ -97,7 +96,9 @@ pub fn pin_version_numbers_in_internal_packages(
     }
 
     if opts.check_only && exit_code != 0 {
-        return Err("Found unexpected dependency versions for internal packages".into());
+        return Err(anyhow!(
+            "Found unexpected dependency versions for internal packages"
+        ));
     }
     Ok(())
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,20 +1,19 @@
 use std::collections::HashMap;
-use std::error::Error;
+
+use anyhow::Result;
 
 use crate::opts;
 
 use crate::configuration_file::ConfigurationFile;
 use crate::monorepo_manifest::MonorepoManifest;
 
-pub fn handle_subcommand(opts: crate::opts::Query) -> Result<(), Box<dyn Error>> {
+pub fn handle_subcommand(opts: crate::opts::Query) -> Result<()> {
     match opts.subcommand {
         opts::ClapQuerySubCommand::InternalDependencies(args) => query_internal_dependencies(&args),
     }
 }
 
-fn query_internal_dependencies(
-    opts: &crate::opts::InternalDependencies,
-) -> Result<(), Box<dyn Error>> {
+fn query_internal_dependencies(opts: &crate::opts::InternalDependencies) -> Result<()> {
     let lerna_manifest =
         MonorepoManifest::from_directory(&opts.root).expect("Unable to read monorepo manifest");
 

--- a/src/typescript_config.rs
+++ b/src/typescript_config.rs
@@ -1,7 +1,8 @@
-use std::error::Error;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
+
+use anyhow::Result;
 
 use crate::configuration_file::ConfigurationFile;
 
@@ -14,7 +15,7 @@ pub struct TypescriptConfig {
 impl ConfigurationFile<TypescriptConfig> for TypescriptConfig {
     const FILENAME: &'static str = "tsconfig.json";
 
-    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<TypescriptConfig, Box<dyn Error>>
+    fn from_directory<P>(monorepo_root: P, directory: P) -> Result<TypescriptConfig>
     where
         P: AsRef<Path>,
     {
@@ -37,7 +38,7 @@ impl ConfigurationFile<TypescriptConfig> for TypescriptConfig {
         self.directory.join(Self::FILENAME)
     }
 
-    fn write(&self) -> Result<(), Box<dyn Error>> {
+    fn write(&self) -> Result<()> {
         let file = File::create(
             self.monorepo_root
                 .join(&self.directory)


### PR DESCRIPTION
The `lint-dependency-version` subcommand takes a list of dependencies,
and for each dependency will test that there is at most one version
of that dependency in use throughout the target monorepo.

If this condition is violated, the command will exit non-zero exit code.

The plan is to use this in CI to enforce monorepo invariants for using
only a single version of a given external dependency; for example,
`typescript`.

Ideally we separate out the library and binary code in this crate,
and later we can write multiple binaries that use this library, one
of which will invoke this new code and can function as a stand-alone
Drone plugin. Thinking about it now, the coupling to Drone is not a
goal of this crate but importing the library portion of this codebase
from a different crate will be a prerequisite for the plugin.

Also:

- separate the package into binary and library crates
- read monorepo manifest files in parallel