### PR TITLE
ci: use concurrency limits to prevent release issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ name: CI
 
 on: [ pull_request ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # This pipeline validates proposed changes.
 #
 # CI pipeline based on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [ master, alpha, beta ]
 
+# Only allow one release workflow to execute at a time, since each release
+# workflow uses shared resources (git tags, package registries)
+concurrency:
+  group: ${{ github.workflow }}
+
 # semantic-release is built around the following idea:
 #
 # > A release consist in running test, defining the version then releasing


### PR DESCRIPTION
Ticket: concurrency-throttle-on-gha-workflows